### PR TITLE
Change archive file extension from .gz to .tgz

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,4 @@
+# InformationGerrymandering
+Data and Scripts associated with paper "Information Gerrymandering and Undemocratic Decisions"
+
+Unpack with `tar -xvzf Data-and-Scripts.gz`


### PR DESCRIPTION
On Linux Mate ubuntu 16.04, `tar` expects the extension `.tgz` instead of `.gz`.

On a Macintosh, your mileage may vary.